### PR TITLE
feat: create task schema, query and mutation

### DIFF
--- a/graphql_task_manager/schema.py
+++ b/graphql_task_manager/schema.py
@@ -1,0 +1,13 @@
+import graphene
+import task_manager.schema
+
+
+class Query(task_manager.schema.Query, graphene.ObjectType):
+    pass
+
+
+class Mutation(task_manager.schema.Mutation, graphene.ObjectType):
+    pass
+
+
+schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/graphql_task_manager/settings.py
+++ b/graphql_task_manager/settings.py
@@ -82,6 +82,10 @@ DATABASES = {
     }
 }
 
+GRAPHENE = {
+    'SCHEMA': 'graphql_task_manager.schema.schema',
+}
+
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
@@ -105,9 +109,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'pt-br'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Sao_Paulo'
 
 USE_I18N = True
 

--- a/graphql_task_manager/urls.py
+++ b/graphql_task_manager/urls.py
@@ -16,7 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
+from graphene_django.views import GraphQLView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('graphql/', csrf_exempt(GraphQLView.as_view(graphiql=True))),
 ]

--- a/task_manager/schema.py
+++ b/task_manager/schema.py
@@ -1,0 +1,39 @@
+import graphene
+from graphene_django.types import DjangoObjectType
+from task_manager.models import Task
+
+
+class TaskType(DjangoObjectType):
+    class Meta:
+        model = Task
+
+
+class Query(graphene.ObjectType):
+    all_tasks = graphene.List(TaskType)
+
+    def resolve_all_tasks(self, info):
+        return Task.objects.all()
+
+
+class CreateTask(graphene.Mutation):
+    id = graphene.Int()
+    title = graphene.String()
+    completed = graphene.Boolean()
+
+    class Arguments:
+        title = graphene.String()
+        completed = graphene.Boolean()
+
+    def mutate(self, info, title, completed):
+        task = Task(title=title, completed=completed)
+        task.save()
+
+        return CreateTask(
+            id=task.id,
+            title=task.title,
+            completed=task.completed,
+        )
+
+
+class Mutation(graphene.ObjectType):
+    create_task = CreateTask.Field()


### PR DESCRIPTION
# Context

1. Created task [schema](https://github.com/MarinaSpadetto/task_manager_graphql/blob/fe1e4e235a3ccab3262a5a9abbe92c03820a3824/task_manager/schema.py#L6).
2. Created a [query](https://github.com/MarinaSpadetto/task_manager_graphql/blob/fe1e4e235a3ccab3262a5a9abbe92c03820a3824/task_manager/schema.py#L14) that returns all tasks.
3. Created a [schema](https://github.com/MarinaSpadetto/task_manager_graphql/blob/fe1e4e235a3ccab3262a5a9abbe92c03820a3824/graphql_task_manager/schema.py#L1) principal. This query just inherits the query defined before. This way, you are able to keep every part of the schema isolated in the apps.